### PR TITLE
Stretch compatibility : create ereg() if it does not exists

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -1,5 +1,12 @@
 <?php
 
+if (!function_exists('ereg')) {
+   function ereg($pattern, $subject, &$matches = array())
+   {
+       return preg_match('/'.$pattern.'/', $subject, $matches);
+   }
+}
+
 function arguments($argv) {
 	$_ARG = array();
 	foreach ($argv as $arg) {


### PR DESCRIPTION
As we move toward Stretch, it was noticed that the install of Rainloop doesn't work because of ereg() (in `config.php`) not being available in Php7.

This is a simple fix to define `ereg()` in `config.php` (which is the only place where it's needed I suppose ? I would expect the actual rainloop code to be compatible with Php7). The piece of code is adapated from : https://github.com/bbrala/php7-ereg-shim/blob/master/lib/ereg.php