### PR TITLE
Temporary fix for getopts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 		"en": "Lightweight multi-account webmail",
 		"fr": "Webmail léger multi-comptes"
 	},
-	"version": "1.12.1~ynh2",
+	"version": "1.12.1~ynh3",
 	"url": "https://www.rainloop.net/",
 	"license": "AGPL-3.0-or-later",
 	"maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -58,10 +58,6 @@
 					"en": "Set the administrator password",
 					"fr": "Définissez le mot de passe administrateur"
 				},
-				"help": {
-					"en": "Use the help field to add an information for the admin about this question.",
-					"fr": "Utilisez le champ aide pour ajouter une information à l'intention de l'administrateur à propos de cette question."
-				},
 				"example": "Choose a password"
 			},
 			{

--- a/scripts/install
+++ b/scripts/install
@@ -136,8 +136,10 @@ ynh_replace_string --match_string="__MYSQLUSER__" --replace_string=$db_name --ta
 ynh_replace_string --match_string="__MYSQLPASSWORD__" --replace_string="$db_pwd" --target_file="$application_file"
 ynh_replace_string --match_string="__LANGTOCHANGE__" --replace_string=$lang --target_file="$application_file"
 ynh_replace_string --match_string="__PLUGINSTOENABLE__" --replace_string="$plugins" --target_file="$application_file"
-ynh_replace_string --match_string="__TIME_ZONE__" --replace_string="$(date +%:::z)" --target_file="$application_file"
-
+# FIXME Temporary fix for rainloop, waiting for https://github.com/YunoHost/yunohost/pull/752 to be released.
+# ynh_replace_string --match_string="__TIME_ZONE__" --replace_string="$(date +%:::z)" --target_file="$application_file"
+timezone="$(date +%:::z)"
+ynh_replace_string --match_string="__TIME_ZONE__" --replace_string="${timezone//-/\\-}" --target_file="$application_file"
 
 # Set admin password
 php ../conf/config.php --index="$final_path/app/index.php" --password="$password"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -122,7 +122,10 @@ ynh_add_fpm_config
 ynh_script_progression --message="Upgrading rainloop configuration..."
 
 # Upgrade time_offset value for fail2ban
-ynh_replace_string --match_string="^time_offset = .*" --replace_string="time_offset = $(date +%:::z)" --target_file="$final_path/app/data/_data_/_default_/configs/application.ini"
+# FIXME Temporary fix for rainloop, waiting for https://github.com/YunoHost/yunohost/pull/752 to be released.
+# ynh_replace_string --match_string="^time_offset = .*" --replace_string="time_offset = $(date +%:::z)" --target_file="$final_path/app/data/_data_/_default_/configs/application.ini"
+timezone="$(date +%:::z)"
+ynh_replace_string --match_string="^time_offset = .*" --replace_string="time_offset = ${timezone//-/\\-}" --target_file="$final_path/app/data/_data_/_default_/configs/application.ini"
 
 # update SSO
 cp ../sources/sso/sso.php "$final_path/index.php"


### PR DESCRIPTION
## Problem
- *Getopts fails to parse a value if it's start by -. It's misread as another option in the argument list.*

## Solution
- *Fix #58*
- *This is a temporary fix on rainloop part, see https://github.com/YunoHost/yunohost/pull/752 for a general fix.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/rainloop_ynh%20PR60/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/rainloop_ynh%20PR60/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.